### PR TITLE
Enhancements for supporting multiple identity providers, and a few other changes.

### DIFF
--- a/core/src/main/java/org/springframework/security/extensions/saml2/config/SAMLConfigurer.java
+++ b/core/src/main/java/org/springframework/security/extensions/saml2/config/SAMLConfigurer.java
@@ -217,18 +217,6 @@ public class SAMLConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFil
 	}
 
 	/**
-	 * Sets maximum time between users authentication and processing of an
-	 * authentication statement.
-	 *
-	 * @param maxSeconds authentication age (in seconds)
-	 * @return The SAMLConfigurer so we can chain methods.
-	 */
-	public SAMLConfigurer maxAuthenticationAge(int maxSeconds) {
-		webSSOProfileConsumer.setMaxAuthenticationAge(maxSeconds);
-		return this;
-	}
-
-	/**
  	 * Use a different authentication provider for populating the Security
  	 * Context when a SAML login happens.
  	 *
@@ -644,6 +632,13 @@ public class SAMLConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFil
 			return this;
 		}
 
+		/**
+		 * Sets maximum time between users authentication and processing of an
+		 * authentication statement.
+		 *
+		 * @param maxAuthenticationAge authentication age (in seconds)
+		 * @return The SAMLConfigurer so we can chain methods.
+		 */
 		public ServiceProvider maxAuthenticationAge(long maxAuthenticationAge) {
 			this.maxAuthenticationAge = maxAuthenticationAge;
 			return this;

--- a/core/src/main/java/org/springframework/security/extensions/saml2/config/SAMLConfigurer.java
+++ b/core/src/main/java/org/springframework/security/extensions/saml2/config/SAMLConfigurer.java
@@ -183,6 +183,21 @@ public class SAMLConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFil
 		return new SAMLConfigurer();
 	}
 
+	public SAMLConfigurer userDetailsService(SAMLUserDetailsService samlUserDetailsService) {
+		this.samlUserDetailsService = samlUserDetailsService;
+		return this;
+	}
+
+	public SAMLConfigurer forcePrincipalAsString() {
+		this.forcePrincipalAsString = true;
+		return this;
+	}
+
+	public SAMLConfigurer webSSOProfileConsumer(WebSSOProfileConsumerImpl webSSOProfileConsumer) {
+		this.webSSOProfileConsumer = webSSOProfileConsumer;
+		return this;
+	}
+
 	/**
 	 * Use a different signature algorithm than the default "SHA1".
 	 * @param name the name of the algorithm, such as "RSA"
@@ -201,23 +216,30 @@ public class SAMLConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFil
 		return this;
 	}
 
-	public SAMLConfigurer userDetailsService(SAMLUserDetailsService samlUserDetailsService) {
-		this.samlUserDetailsService = samlUserDetailsService;
-		return this;
-	}
-
-	public SAMLConfigurer forcePrincipalAsString() {
-		this.forcePrincipalAsString = true;
-		return this;
-	}
-
-	public SAMLConfigurer webSSOProfileConsumer(WebSSOProfileConsumerImpl webSSOProfileConsumer) {
-		this.webSSOProfileConsumer = webSSOProfileConsumer;
-		return this;
-	}
-
+	/**
+	 * Sets maximum time between users authentication and processing of an
+	 * authentication statement.
+	 *
+	 * @param maxSeconds authentication age (in seconds)
+	 * @return The SAMLConfigurer so we can chain methods.
+	 */
 	public SAMLConfigurer maxAuthenticationAge(int maxSeconds) {
 		webSSOProfileConsumer.setMaxAuthenticationAge(maxSeconds);
+		return this;
+	}
+
+	/**
+ 	 * Use a different authentication provider for populating the Security
+ 	 * Context when a SAML login happens.
+ 	 *
+ 	 * @param samlAuthenticationProvider an instance of
+ 	 * {@code SAMLAuthenticationProvider} that will do the work of
+ 	 * authenticating the user in the SAML assertion.  This is really handy
+ 	 * when we want to trust an IDP for authentication, but not authorization.
+ 	 * @return The SAMLConfigurer so we can chain methods.
+ 	 */
+	public SAMLConfigurer authenticationProvider(SAMLAuthenticationProvider samlAuthenticationProvider) {
+		this.samlAuthenticationProvider = samlAuthenticationProvider;
 		return this;
 	}
 
@@ -410,7 +432,10 @@ public class SAMLConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFil
 	}
 
 	private SAMLAuthenticationProvider samlAuthenticationProvider(WebSSOProfileConsumerImpl webSSOProfileConsumer) {
-		SAMLAuthenticationProvider samlAuthenticationProvider = new SAMLAuthenticationProvider();
+		// If we weren't given a provider, use the default.
+		if ( samlAuthenticationProvider == null ) {
+			samlAuthenticationProvider = new SAMLAuthenticationProvider();
+		}
 		samlAuthenticationProvider.setForcePrincipalAsString(forcePrincipalAsString);
 		samlAuthenticationProvider.setSamlLogger(samlLogger);
 		samlAuthenticationProvider.setConsumer(webSSOProfileConsumer);

--- a/core/src/main/java/org/springframework/security/extensions/saml2/config/SAMLConfigurer.java
+++ b/core/src/main/java/org/springframework/security/extensions/saml2/config/SAMLConfigurer.java
@@ -141,8 +141,7 @@ public class SAMLConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFil
 
 		// If we wanted a different signing algorithm, apply it here.  This
 		// needs to happen after bootstrapping, but before we define anything
-		// else, which is what prevents us from doing something more elegant
-		// like .registerSigningAlgoritum() in the client app.
+		// else.
 		if ( signingAlgorithm != null ) {
 			BasicSecurityConfiguration config =
 					(BasicSecurityConfiguration)Configuration.getGlobalSecurityConfiguration();
@@ -185,8 +184,7 @@ public class SAMLConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFil
 	}
 
 	/**
-	 * Apply the saml configuration, but use a different signature algorithm
-	 * than the default "SHA1".
+	 * Use a different signature algorithm than the default "SHA1".
 	 * @param name the name of the algorithm, such as "RSA"
 	 * @param algorithm the URI of the algorithm to use.  This should be one of
 	 * the algorithms in {@code SignatureConstants}
@@ -194,14 +192,13 @@ public class SAMLConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFil
 	 * the algorithms in {@code SignatureConstants}
 	 * @return a properly configured SAMLConfigurer.
 	 */
-	public static SAMLConfigurer saml(String name, String algorithm, String digest) {
+	public SAMLConfigurer signingAlgorithm(String name, String algorithm, String digest) {
 		// We can't initialize the signing algorithm until after we've
 		// bootstrapped SAML, so make a note of the args for later.
-		SAMLConfigurer configurer = new SAMLConfigurer();
-		configurer.signingAlgorithmName = name;
-		configurer.signingAlgorithm = algorithm;
-		configurer.signingDigest = digest;
-		return configurer;
+		signingAlgorithmName = name;
+		signingAlgorithm = algorithm;
+		signingDigest = digest;
+		return this;
 	}
 
 	public SAMLConfigurer userDetailsService(SAMLUserDetailsService samlUserDetailsService) {
@@ -461,6 +458,7 @@ public class SAMLConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFil
 
 		private String metadataFilePath;
 		private boolean discoveryEnabled = true;
+		private boolean metadataTrustCheckEnabled = true;
 
 		public IdentityProvider metadataFilePath(String metadataFilePath) {
 			this.metadataFilePath = metadataFilePath;
@@ -469,6 +467,11 @@ public class SAMLConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFil
 
 		public IdentityProvider discoveryEnabled(boolean discoveryEnabled) {
 			this.discoveryEnabled = discoveryEnabled;
+			return this;
+		}
+
+		public IdentityProvider metadataTrustCheckEnabled(boolean metadataTrustCheckEnabled) {
+			this.metadataTrustCheckEnabled = metadataTrustCheckEnabled;
 			return this;
 		}
 


### PR DESCRIPTION
This pull request addresses several issues reported against the DSL and adds several new features to it.

1. Added the ability to change the signing algorithm from the default SHA1 (Resolves #54 )

2. Added The ability to change the authentication provider that gets used to validate the SAML assertion.  This is useful when we want to trust the IDP for authentication,  but not authorization. (Resolves #54)

3. Added a way to provide a custom AuthenticationSuccessHandler and AuthenticationFailureHandler to be used when SAML logins succeed or fail.  This  might address Issue #50.  This is also discussed in Issue #52, and Pull Request #53.  I'm not sure how it was implemented in #53, so care would need to be taken before merging it in.

4. Added support for multiple Identitiy Providers.  Each time you call `identityProvider`(), it adds a new one to the list. (Resolves #55)

5. Added a way to configure SAML via a delegateConfig method. This is useful for doing things like reading all the SAML metadata from a directory and creating an IDP for each file.  This is also part of Issue #55, which also has an example of how to use the delegate.

I don't have good  unit tests for this code, but I have used all of my changes in our application, and they seem to work, and the changes don't break any of the existing unit tests.


