### PR TITLE
URL Cleanup

### DIFF
--- a/spring-security-saml-dsl/build.gradle
+++ b/spring-security-saml-dsl/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        maven { url 'http://repo.spring.io/plugins-release' }
+        maven { url 'https://repo.spring.io/plugins-release' }
     }
     dependencies {
         classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
@@ -18,7 +18,7 @@ targetCompatibility = 1.8
 repositories {
     mavenCentral()
     maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases/' }
-    maven { url 'http://repository.mulesoft.org/releases/'}
+    maven { url 'https://repository.mulesoft.org/releases/'}
 }
 
 dependencies {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://repository.mulesoft.org/releases/ migrated to:  
  https://repository.mulesoft.org/releases/ ([https](https://repository.mulesoft.org/releases/) result 200).
* http://repo.spring.io/plugins-release migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).