### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        maven { url 'http://repo.spring.io/plugins-release' }
+        maven { url 'https://repo.spring.io/plugins-release' }
     }
     dependencies {
         classpath("org.springframework.build.gradle:propdeps-plugin:0.0.7")
@@ -30,7 +30,7 @@ configure(allprojects) { project ->
     repositories {
         mavenCentral()
         maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases/' }
-        maven { url 'http://repository.mulesoft.org/releases/'}
+        maven { url 'https://repository.mulesoft.org/releases/'}
     }
 }
 

--- a/gradle/publish-maven.gradle
+++ b/gradle/publish-maven.gradle
@@ -46,7 +46,7 @@ def customizePom(pom, gradleProject) {
 			licenses {
 				license {
 					name "The Apache Software License, Version 2.0"
-					url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+					url "https://www.apache.org/licenses/LICENSE-2.0.txt"
 					distribution "repo"
 				}
 			}
@@ -82,13 +82,13 @@ def customizePom(pom, gradleProject) {
 			}
 			issueManagement {
 				system = "jira"
-				url = "http://jira.springsource.org/browse/SES"
+				url = "https://jira.springsource.org/browse/SES"
 			}
 			mailingLists {
 				mailingList {
 					name = "Spring Security SAML Forum"
-					post = "http://stackoverflow.com/questions/tagged/spring-security"
-					archive = "http://stackoverflow.com/questions/tagged/spring-security"
+					post = "https://stackoverflow.com/questions/tagged/spring-security"
+					archive = "https://stackoverflow.com/questions/tagged/spring-security"
 				}
 			}
 		}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://repository.mulesoft.org/releases/ migrated to:  
  https://repository.mulesoft.org/releases/ ([https](https://repository.mulesoft.org/releases/) result 200).
* http://stackoverflow.com/questions/tagged/spring-security migrated to:  
  https://stackoverflow.com/questions/tagged/spring-security ([https](https://stackoverflow.com/questions/tagged/spring-security) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://jira.springsource.org/browse/SES migrated to:  
  https://jira.springsource.org/browse/SES ([https](https://jira.springsource.org/browse/SES) result 301).
* http://repo.spring.io/plugins-release migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).