### PR TITLE
URL Cleanup

### DIFF
--- a/core/src/test/resources/saml/metadata.xml
+++ b/core/src/test/resources/saml/metadata.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
-                     entityID="http://www.okta.com/exk5zn8pgvIUEnKkQ0h7">
+                     entityID="https://www.okta.com/exk5zn8pgvIUEnKkQ0h7">
     <md:IDPSSODescriptor WantAuthnRequestsSigned="true"
                          protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         <md:KeyDescriptor use="signing">
-            <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:KeyInfo xmlns:ds="https://www.w3.org/2000/09/xmldsig#">
                 <ds:X509Data>
                     <ds:X509Certificate>MIIDpDCCAoygAwIBAgIGAVNmAiVZMA0GCSqGSIb3DQEBBQUAMIGSMQswCQYDVQQGEwJVUzETMBEG
                         A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.okta.com/exk5zn8pgvIUEnKkQ0h7 with 1 occurrences migrated to:  
  https://www.okta.com/exk5zn8pgvIUEnKkQ0h7 ([https](https://www.okta.com/exk5zn8pgvIUEnKkQ0h7) result 301).
* http://www.w3.org/2000/09/xmldsig with 1 occurrences migrated to:  
  https://www.w3.org/2000/09/xmldsig ([https](https://www.w3.org/2000/09/xmldsig) result 303).