### PR TITLE
URL Cleanup

### DIFF
--- a/core/src/test/java/org/springframework/security/extensions/saml2/config/SAMLConfigurerProfileConsumerTests.java
+++ b/core/src/test/java/org/springframework/security/extensions/saml2/config/SAMLConfigurerProfileConsumerTests.java
@@ -74,7 +74,7 @@ public class SAMLConfigurerProfileConsumerTests {
 
 		assertThat(samlMessageContext).isNotNull();
 		assertThat(samlMessageContext.getInboundSAMLMessageId()).isEqualTo("id61844979402263501352984461");
-		assertThat(samlMessageContext.getPeerEntityId()).isEqualTo("http://www.okta.com/exkb5v2p0pp35JFKa0h7");
+		assertThat(samlMessageContext.getPeerEntityId()).isEqualTo("https://www.okta.com/exkb5v2p0pp35JFKa0h7");
 	}
 
 	private SAMLCredential stubSAMLCredential() {

--- a/core/src/test/java/org/springframework/security/extensions/saml2/config/SAMLConfigurerTests.java
+++ b/core/src/test/java/org/springframework/security/extensions/saml2/config/SAMLConfigurerTests.java
@@ -57,7 +57,7 @@ public class SAMLConfigurerTests {
 
 	@Test
 	public void loginRendersSAMLRequest() throws Exception {
-		mockMvc.perform(get("/saml/login").param("disco", "true").param("idp","http://www.okta.com/exk5id72igJRNtH5M0h7"))
+		mockMvc.perform(get("/saml/login").param("disco", "true").param("idp","https://www.okta.com/exk5id72igJRNtH5M0h7"))
 			.andExpect(status().isOk())
 			.andExpect(content().string(containsString("<input type=\"hidden\" name=\"SAMLRequest\" value=\"")));
 

--- a/core/src/test/resources/templates/index.html
+++ b/core/src/test/resources/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
 <head>
     <title>Spring Security Example</title>
 </head>

--- a/samples/spring-security-saml-dsl-sample/README.md
+++ b/samples/spring-security-saml-dsl-sample/README.md
@@ -1,7 +1,7 @@
 ## Set up a test okta
 
 #### Basic setup
-1. Navigate to [http://developer.okta.com/](http://developer.okta.com/)
+1. Navigate to [https://developer.okta.com/](https://developer.okta.com/)
 1. Click on *Sign Up*
 1. Fill in your own name and email address to register, or login if you already have 
 1. Okta will send you a confirmation email, including your temporary password and a link to your new developer Okta instance

--- a/samples/spring-security-saml-dsl-sample/src/main/resources/templates/index.html
+++ b/samples/spring-security-saml-dsl-sample/src/main/resources/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
 <head>
     <title>Spring Security Example</title>
 </head>

--- a/samples/spring-security-saml-dsl-sample/src/main/resources/templates/login.html
+++ b/samples/spring-security-saml-dsl-sample/src/main/resources/templates/login.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org"
-      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org"
+      xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
 <head>
     <title>Spring Security Example </title>
 </head>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.thymeleaf.org/thymeleaf-extras-springsecurity3 (301) with 3 occurrences migrated to:  
  https://www.thymeleaf.org/thymeleaf-extras-springsecurity3 ([https](https://www.thymeleaf.org/thymeleaf-extras-springsecurity3) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://developer.okta.com/ with 2 occurrences migrated to:  
  https://developer.okta.com/ ([https](https://developer.okta.com/) result 200).
* [ ] http://www.thymeleaf.org with 3 occurrences migrated to:  
  https://www.thymeleaf.org ([https](https://www.thymeleaf.org) result 200).
* [ ] http://www.okta.com/exk5id72igJRNtH5M0h7 with 1 occurrences migrated to:  
  https://www.okta.com/exk5id72igJRNtH5M0h7 ([https](https://www.okta.com/exk5id72igJRNtH5M0h7) result 301).
* [ ] http://www.okta.com/exkb5v2p0pp35JFKa0h7 with 1 occurrences migrated to:  
  https://www.okta.com/exkb5v2p0pp35JFKa0h7 ([https](https://www.okta.com/exkb5v2p0pp35JFKa0h7) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8443 with 1 occurrences
* http://www.w3.org/1999/xhtml with 3 occurrences